### PR TITLE
reworked pokemon/abilities

### DIFF
--- a/ability.js
+++ b/ability.js
@@ -1,0 +1,77 @@
+// ABILITIES
+/*
+Abilities...
+- Are procced when certain conditions are met
+
+Feed data about the turn to the abilty's check? Return a boolean determining whether
+the ability has been procced or not?
+*/
+
+class ABILITY {
+  constructor(
+    name, description, check
+  ) {
+    this.name = name;
+    this.description = description;
+    this.check = check; // Run a check to determine the ability's activation
+  };
+
+  determine_proc(data) {
+    return this.check(data)
+  };
+};
+
+// const flame_body = new ABILITY(
+//   "Flame Body",
+//   "If the user is hit with a contact move, there is a chance to burn the attacker.",
+//   ((data) => {
+//     let proc = {
+//       "procced": false,
+//       "effect": ((pokemon) => {
+//         pokemon.status = burn;
+//       }),
+//       "message": null
+//     }
+//     if (data.foe.action.move.contact === true) {
+//       const base = 255;
+//       const chance = Math.floor(Math.random() * Math.sqrt(base));
+//       if (chance > base) {
+//         proc.procced = true;
+//         proc.effect(data.foe);
+//         proc.message = `The foe was burned by ${data.ally.nickname ? data.ally.nickname : data.ally.name}'s Flame Body!`
+//         return proc;
+//       }
+//     }
+//     return proc;
+//   }),
+// );
+
+const overgrow = new ABILITY(
+  "Overgrow",
+  "When the user's HP is at or below half, they gain a boost to their Grass type moves.",
+  // Ability's Check (Fed data about the battle)
+  ((data) => {
+    // Instantiate the proc, holding data about whether the check passes, and the effect that takes place within.
+    let proc = {
+      "procced": false,
+      "effect": ((pokemon) => {
+        // In Overgrow's case, we want to increase the value of the Pokemon's ability multiplier;
+        pokemon.battleStats.abm = 1.5;
+      }),
+      "message": null,
+    }
+    // If the move type is Grass and the attacking pokemon's HP is less than half
+    if (data.ally.action.move.type === "Grass" && (data.ally.battleStats.hitPoints <= data.ally.battleStats.hitPoints / 2)) {
+      // Proc the ability
+      proc.procced = true;
+      // Trigger the ability's effect
+      proc.effect(data.ally)
+      return proc;
+    }
+    // If conditions change, reassign the ABM to 1
+    data.ally.battleStats.abm = 1;
+    return proc;
+  })
+);
+
+module.exports.overgrow = overgrow

--- a/natures.js
+++ b/natures.js
@@ -57,3 +57,5 @@ const natures = [
   modest, mild, quiet, bashful, rash,
   calm, gentle, sassy, careful, quirky,
 ];
+
+module.exports.natures = natures;

--- a/pokemon.js
+++ b/pokemon.js
@@ -1,3 +1,5 @@
+const { natures } = require('./natures');
+
 // POKEMON
 
 class Pokemon {
@@ -39,9 +41,10 @@ class Pokemon {
       spa: Math.floor(((2 * this.baseStats["spa"] + this.ivs["spa"] * this.level) / 100) + 5 * (this.nature.buff === "spa" ? 1.1 : 1 || this.nature.nerf === "spa" ? 0.9 : 1)),
       spd: Math.floor(((2 * this.baseStats["spd"] + this.ivs["spd"] * this.level) / 100) + 5 * (this.nature.buff === "spd" ? 1.1 : 1 || this.nature.nerf === "spd" ? 0.9 : 1)),
     };
-    // Battle Stats (hitPoints represents the real value that will change during battle, acc represents the hidden accuracty stat, and eva the hidden evasion stat)
+    // Battle Stats (hitPoints represents the real value that will change during battle, abm represents any ability multipliers, acc represents the hidden accuracty stat, and eva the hidden evasion stat)
     this.battleStats = {
       hitPoints: this.stats.hp,
+      abm: 1,
       acc: 100,
       eva: 100
     };
@@ -58,15 +61,6 @@ class Pokemon {
     this.stockpile = 0;
     this.evolvesFrom = evolvesFrom;
     this.evolvesTo = evolvesTo;
-  };
-
-  applyNature() {
-    if (this.nature.buff === null) {
-      return;
-    };
-    this.stats[this.nature.buff] = Math.floor(this.stats[this.nature.buff] * 1.1);
-    this.stats[this.nature.nerf] = Math.floor(this.stats[this.nature.nerf] * 0.9);
-    return;
   };
 
   applyNickname(value) {


### PR DESCRIPTION
POKEMON
- Nature bonus/penalty now calculated directly within stat calculation. applyNature method removed
- IVs are implemented and used in stat calculation
- Moves property now assigned to an object to be filled
- battleStats property added to track hit points, accuracy and evasion, and ability multipliers

ABILITIES
- Abilities now run a more succinct check that is fed battle data and returns data about ability's activation.